### PR TITLE
Add vern's binternet instance to list

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@
 | [binternet.ahwx.org](https://binternet.ahwx.org/) | no | no | 🇳🇱 NL (Official Instance) |
 | [pinternet.revvy.de](https://pinternet.revvy.de/) | [yes!](http://pinternet.revvybrr6pvbx4n3j4475h4ghw4elqr4t5xo2vtd3gfpu2nrsnhh57id.onion/) | [yes!](http://revznkqdwy7nmlzql66x226g3qnapiooss3rg2uajbj4rypxjnba.b32.i2p/) | 🇨🇦 CA |
 | [pinternet.bloatcat.tk](https://pinternet.bloatcat.tk/) | no | no | 🇮🇸 IS |
+| [bn.vern.cc](https://bn.vern.cc) | [yes!](http://bn.vernccvbvyi5qhfzyqengccj7lkove6bjot2xhh5kajhwvidqafczrad.onion/) | [yes!](http://verne3vnw4i3qffozcjygtnv4uedwedtevxe7aoht7fngduuwcpa.b32.i2p/) | 🇺🇸 US |
 <br>
 
 


### PR DESCRIPTION
This commit adds vern's Binternet instance to the list in the README file.

Submitted on behalf of cobra, the vern administrator.