### PR TITLE
Mimic pinterest image view on search page

### DIFF
--- a/misc/style-dark.css
+++ b/misc/style-dark.css
@@ -148,23 +148,19 @@ button {
   height: 100%;
   width: 100%;
   object-fit: cover;
+  border-radius:  0.2rem;
 }
 
 .img-container{
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  flex-wrap: wrap;
-  grid-gap: 10px;
-  margin-bottom: 50px;
-  margin-left: 20px;
-  margin-right: 20px;
-
+  column-count: auto;
+  column-width: 14rem;
+  column-gap: 0.5rem;
+  padding: 1rem;
 }
 
 .img-result {
-  flex-grow: 1;
-  height: 12rem;
+  margin-bottom: 0.5rem;
+  display: block;
 }
 
 /* search css end */


### PR DESCRIPTION
Just found this project while searching for a decent way to view Pinterest without an account cause I can't stand the ads anymore... Love it besides this tiny thing.

I just edited the CSS a bit to have images show up in columns similar to Pinterest. It leaves some awkward spacing at the bottom, but I think it's a better solution than the current flexbox which crops images pretty bad. If you implement some kind of infinite scroll I'm not sure how this would hold up, but as it is now I believe this is a minor improvement. The column width is arbitrary and looks good on my screen, but you may want to adjust it for other screen sizes!

I only tested it with a user style extension on Firefox, but it's a small enough change that I don't think it should break anything.

Here is a short GIF of what the change looks like:

![ezgif-5-db35b8382b](https://github.com/Ahwxorg/Binternet/assets/58575812/d8cd09e7-242e-4b51-a2fe-d94671c1ec3a)
