### PR TITLE
base docker on Alpine 3.19, update to PHP 8.3, remove dead instances

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,17 @@
-FROM nginx:mainline-alpine-slim
+FROM alpine:3.19
 
-RUN apk add php82 php82-fpm php82-dom php82-curl php82-json php82-openssl --no-cache
-RUN sed -i 's/user  nginx;/user  nobody;/' /etc/nginx/nginx.conf \
-    && sed -i 's/listen = 127.0.0.1:9000/listen = \/run\/php-fpm82.sock/' /etc/php82/php-fpm.d/www.conf \
-    && sed -i 's/;listen.owner/listen.owner/' /etc/php82/php-fpm.d/www.conf \
-    && sed -i 's/;listen.group/listen.group/' /etc/php82/php-fpm.d/www.conf \
-    && sed -i 's/;listen.mode/listen.mode/' /etc/php82/php-fpm.d/www.conf \
-    && sed -i 's/;listen.allowed_clients/listen.allowed_clients/' /etc/php82/php-fpm.d/www.conf
+RUN apk add php83 php83-fpm php83-dom php83-curl php83-json php83-openssl nginx --no-cache
+RUN sed -i 's/user nginx;/user nobody;/' /etc/nginx/nginx.conf \
+    && sed -i 's/listen = 127.0.0.1:9000/listen = \/run\/php-fpm83.sock/' /etc/php83/php-fpm.d/www.conf \
+    && sed -i 's/;listen.owner/listen.owner/' /etc/php83/php-fpm.d/www.conf \
+    && sed -i 's/;listen.group/listen.group/' /etc/php83/php-fpm.d/www.conf \
+    && sed -i 's/;listen.mode/listen.mode/' /etc/php83/php-fpm.d/www.conf \
+    && sed -i 's/;listen.allowed_clients/listen.allowed_clients/' /etc/php83/php-fpm.d/www.conf
 
 RUN mkdir -p /var/www/binternet
 COPY . /var/www/binternet
-COPY nginx.conf /etc/nginx/conf.d/binternet.conf
-RUN rm /var/www/binternet/nginx.conf /etc/nginx/conf.d/default.conf
+COPY nginx.conf /etc/nginx/http.d/binternet.conf
+RUN rm /var/www/binternet/nginx.conf /etc/nginx/http.d/default.conf
 
 EXPOSE 80
-ENTRYPOINT ["/bin/sh", "-c" , "/usr/sbin/php-fpm82 -D && /usr/sbin/nginx -c /etc/nginx/nginx.conf -g 'daemon off;'"]
+ENTRYPOINT ["/bin/sh", "-c" , "/usr/sbin/php-fpm83 -D && /usr/sbin/nginx -c /etc/nginx/nginx.conf -g 'daemon off;'"]

--- a/README.md
+++ b/README.md
@@ -34,11 +34,9 @@
 | Clearnet | TOR | I2P | Country |
 |-|-|-|-|
 | [binternet.ahwx.org](https://binternet.ahwx.org/) | no | no | 🇳🇱 NL (Official Instance) |
-| [binternet.revvy.de](https://binternet.revvy.de/) | [yes!](http://binternet.revvybrr6pvbx4n3j4475h4ghw4elqr4t5xo2vtd3gfpu2nrsnhh57id.onion/) | [yes!](http://revznkqdwy7nmlzql66x226g3qnapiooss3rg2uajbj4rypxjnba.b32.i2p/) | 🇨🇦 CA |
 | no clearnet address | [yes!](http://binternet.skunky7dhv7nohsoalpwe3sxfz3fbkad7r3wk632riye25vqm3meqead.onion/) | [yes!](http://5cv2aw6jhe6la444vpn3jvo46442ls3ccgp3difx5ddlv5yf4hlq.b32.i2p/) | 🇷🇺﻿﻿ RU |
 | [bn.bloat.cat](https://bn.bloat.cat/) | no | no | 🇷🇴 RO |
 | [bn.opnxng.com](https://bn.opnxng.com) | no | no | 🇸🇬 SG |
-| [binternet.privacyfucking.rocks](https://binternet.privacyfucking.rocks/) | no | no | 🇩🇪 DE |
 | [binternet.ducks.party](https://binternet.ducks.party) | no | no | 🇳🇱 NL |
 <br>
 

--- a/nginx.conf
+++ b/nginx.conf
@@ -6,7 +6,7 @@ server {
     index    index.php;
 
     location ~ \.php$ {
-        fastcgi_pass   unix:/run/php-fpm82.sock;
+        fastcgi_pass   unix:/run/php-fpm83.sock;
         fastcgi_index  index.php;
         fastcgi_param  PATH_INFO $path_info;
         fastcgi_param  SCRIPT_FILENAME    $document_root$fastcgi_script_name;


### PR DESCRIPTION
The nginx team forgot to update their Docker image to Alpine 3.19, so I switched it over to official Alpine image. The only difference is that nginx now runs the stable version instead of mainline, which doesn't really matter since we're not using HTTP/3.