### PR TITLE
feat: harden security

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,13 +4,13 @@ RUN apk add php83 php83-fpm php83-dom php83-curl php83-json php83-openssl nginx 
 RUN sed -i '/user nginx;/d' /etc/nginx/nginx.conf \
     && sed -i 's/^user = nobody/; user = nobody/' /etc/php83/php-fpm.d/www.conf \
     && sed -i 's/^group = nobody/; group = nobody/' /etc/php83/php-fpm.d/www.conf \
-    && sed -i 's/listen = 127.0.0.1:9000/listen = \/run\/php-fpm83.sock/' /etc/php83/php-fpm.d/www.conf \
+    && sed -i 's/listen = 127.0.0.1:9000/listen = \/run\/php\/php-fpm83.sock/' /etc/php83/php-fpm.d/www.conf \
     && sed -i 's/;listen.owner = nobody/listen.owner = nginx/' /etc/php83/php-fpm.d/www.conf \
     && sed -i 's/;listen.group = nobody/listen.group = nginx/' /etc/php83/php-fpm.d/www.conf \
     && sed -i 's/;listen.mode/listen.mode/' /etc/php83/php-fpm.d/www.conf \
     && sed -i 's/;listen.allowed_clients/listen.allowed_clients/' /etc/php83/php-fpm.d/www.conf
 
-RUN mkdir -p /var/www/binternet
+RUN mkdir -p /var/www/binternet /run/php
 COPY . /var/www/binternet
 COPY nginx.conf /etc/nginx/http.d/binternet.conf
 RUN rm /var/www/binternet/nginx.conf /etc/nginx/http.d/default.conf \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,8 @@ FROM alpine:3.20
 
 RUN apk add php83 php83-fpm php83-dom php83-curl php83-json php83-openssl nginx --no-cache
 RUN sed -i '/user nginx;/d' /etc/nginx/nginx.conf \
-    && sed -i 's/user = nobody/; user = nobody/' /etc/php83/php-fpm.d/www.conf \
-    && sed -i 's/group = nobody/; group = nobody/' /etc/php83/php-fpm.d/www.conf \
+    && sed -i 's/^user = nobody/; user = nobody/' /etc/php83/php-fpm.d/www.conf \
+    && sed -i 's/^group = nobody/; group = nobody/' /etc/php83/php-fpm.d/www.conf \
     && sed -i 's/listen = 127.0.0.1:9000/listen = \/run\/php-fpm83.sock/' /etc/php83/php-fpm.d/www.conf \
     && sed -i 's/;listen.owner = nobody/listen.owner = nginx/' /etc/php83/php-fpm.d/www.conf \
     && sed -i 's/;listen.group = nobody/listen.group = nginx/' /etc/php83/php-fpm.d/www.conf \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,22 @@
 FROM alpine:3.20
 
 RUN apk add php83 php83-fpm php83-dom php83-curl php83-json php83-openssl nginx --no-cache
-RUN sed -i 's/user nginx;/user nobody;/' /etc/nginx/nginx.conf \
+RUN sed -i '/user nginx;/d' /etc/nginx/nginx.conf \
+    && sed -i 's/user = nobody/; user = nobody/' /etc/php83/php-fpm.d/www.conf \
+    && sed -i 's/group = nobody/; group = nobody/' /etc/php83/php-fpm.d/www.conf \
     && sed -i 's/listen = 127.0.0.1:9000/listen = \/run\/php-fpm83.sock/' /etc/php83/php-fpm.d/www.conf \
-    && sed -i 's/;listen.owner/listen.owner/' /etc/php83/php-fpm.d/www.conf \
-    && sed -i 's/;listen.group/listen.group/' /etc/php83/php-fpm.d/www.conf \
+    && sed -i 's/;listen.owner = nobody/listen.owner = nginx/' /etc/php83/php-fpm.d/www.conf \
+    && sed -i 's/;listen.group = nobody/listen.group = nginx/' /etc/php83/php-fpm.d/www.conf \
     && sed -i 's/;listen.mode/listen.mode/' /etc/php83/php-fpm.d/www.conf \
     && sed -i 's/;listen.allowed_clients/listen.allowed_clients/' /etc/php83/php-fpm.d/www.conf
 
 RUN mkdir -p /var/www/binternet
 COPY . /var/www/binternet
 COPY nginx.conf /etc/nginx/http.d/binternet.conf
-RUN rm /var/www/binternet/nginx.conf /etc/nginx/http.d/default.conf
+RUN rm /var/www/binternet/nginx.conf /etc/nginx/http.d/default.conf \
+    && chown -R nginx:nginx /var/log/php83/ /run
 
-EXPOSE 80
+USER nginx
+EXPOSE 8080
 ENTRYPOINT ["/bin/sh", "-c" , "/usr/sbin/php-fpm83 -D && /usr/sbin/nginx -c /etc/nginx/nginx.conf -g 'daemon off;'"]
+HEALTHCHECK --timeout=5s CMD wget --no-verbose --tries=1 --spider 127.0.0.1:8080 || exit 1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,5 +2,12 @@ services:
   binternet:
     container_name: binternet
     image: ghcr.io/ahwxorg/binternet:latest
+    read_only: true
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
     ports:
-     - '8080:80'
+     - '8080:8080'
+    tmpfs:
+      - /var/log:noexec,nosuid,nodev

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,3 +11,4 @@ services:
      - '8080:8080'
     tmpfs:
       - /var/log:noexec,nosuid,nodev
+      - /var/lib:noexec,nosuid,nodev

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,5 +1,5 @@
 server {
-    listen       80 default_server;
+    listen       8080 default_server;
     server_name  _;
 
     root     /var/www/binternet;

--- a/nginx.conf
+++ b/nginx.conf
@@ -6,7 +6,7 @@ server {
     index    index.php;
 
     location ~ \.php$ {
-        fastcgi_pass   unix:/run/php-fpm83.sock;
+        fastcgi_pass   unix:/run/php/php-fpm83.sock;
         fastcgi_index  index.php;
         fastcgi_param  PATH_INFO $path_info;
         fastcgi_param  SCRIPT_FILENAME    $document_root$fastcgi_script_name;


### PR DESCRIPTION
This PR hardens the security of the container by:
 - changing the default user in the container to a non root one (nginx in this case)
 - setting the default port to a non privileged one (8080)
   - please note that this is a potentially breaking change for users setting the old default port in the compose file!
 - dropping all capabilities
 - setting the filesystem as readonly
 - preventing in-container privilege escalation 
 - using a temporary filesystem for the logs inside the container

It also adds a default healthcheck command

For more info see https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-3-limit-capabilities-grant-only-specific-capabilities-needed-by-a-container