### PR TITLE
update alpine, php, instance list; add nginx security headers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,22 @@
-FROM alpine:3.20
+FROM alpine:3.21
 
-RUN apk add php83 php83-fpm php83-dom php83-curl php83-json php83-openssl nginx --no-cache
+RUN apk add php84 php84-fpm php84-dom php84-curl php84-openssl nginx --no-cache
 RUN sed -i '/user nginx;/d' /etc/nginx/nginx.conf \
-    && sed -i 's/^user = nobody/; user = nobody/' /etc/php83/php-fpm.d/www.conf \
-    && sed -i 's/^group = nobody/; group = nobody/' /etc/php83/php-fpm.d/www.conf \
-    && sed -i 's/listen = 127.0.0.1:9000/listen = \/run\/php\/php-fpm83.sock/' /etc/php83/php-fpm.d/www.conf \
-    && sed -i 's/;listen.owner = nobody/listen.owner = nginx/' /etc/php83/php-fpm.d/www.conf \
-    && sed -i 's/;listen.group = nobody/listen.group = nginx/' /etc/php83/php-fpm.d/www.conf \
-    && sed -i 's/;listen.mode/listen.mode/' /etc/php83/php-fpm.d/www.conf \
-    && sed -i 's/;listen.allowed_clients/listen.allowed_clients/' /etc/php83/php-fpm.d/www.conf
+    && sed -i 's/^; user = nobody/user = nobody/' /etc/php84/php-fpm.d/www.conf \
+    && sed -i 's/^; group = nobody/group = nobody/' /etc/php84/php-fpm.d/www.conf \
+    && sed -i 's/listen = 127.0.0.1:9000/listen = \/run\/php\/php-fpm84.sock/' /etc/php84/php-fpm.d/www.conf \
+    && sed -i 's/;listen.owner = nobody/listen.owner = nginx/' /etc/php84/php-fpm.d/www.conf \
+    && sed -i 's/;listen.group = nobody/listen.group = nginx/' /etc/php84/php-fpm.d/www.conf \
+    && sed -i 's/;listen.mode/listen.mode/' /etc/php84/php-fpm.d/www.conf \
+    && sed -i 's/;listen.allowed_clients/listen.allowed_clients/' /etc/php84/php-fpm.d/www.conf
 
 RUN mkdir -p /var/www/binternet /run/php
 COPY . /var/www/binternet
 COPY nginx.conf /etc/nginx/http.d/binternet.conf
 RUN rm /var/www/binternet/nginx.conf /etc/nginx/http.d/default.conf \
-    && chown -R nginx:nginx /var/log/php83/ /run
+    && chown -R nginx:nginx /var/log/php84/ /run
 
 USER nginx
 EXPOSE 8080
-ENTRYPOINT ["/bin/sh", "-c" , "/usr/sbin/php-fpm83 -D && /usr/sbin/nginx -c /etc/nginx/nginx.conf -g 'daemon off;'"]
+ENTRYPOINT ["/bin/sh", "-c" , "/usr/sbin/php-fpm84 -D && /usr/sbin/nginx -c /etc/nginx/nginx.conf -g 'daemon off;'"]
 HEALTHCHECK --timeout=5s CMD wget --no-verbose --tries=1 --spider 127.0.0.1:8080 || exit 1

--- a/README.md
+++ b/README.md
@@ -33,18 +33,16 @@
 
 | Clearnet | TOR | I2P | Country |
 |-|-|-|-|
-| [binternet.ahwx.org](https://binternet.ahwx.org) | no | no | 🇳🇱 NL (Official Instance) |
-| no clearnet address | [yes!](http://binternet.skunky7dhv7nohsoalpwe3sxfz3fbkad7r3wk632riye25vqm3meqead.onion) | [yes!](http://5cv2aw6jhe6la444vpn3jvo46442ls3ccgp3difx5ddlv5yf4hlq.b32.i2p) | 🇷🇺﻿﻿ RU |
-| [bn.bloat.cat](https://bn.bloat.cat) | no | no | 🇩🇪 DE |
-| [bn.opnxng.com](https://bn.opnxng.com) | no | no | 🇸🇬 SG |
-| [binternet.ducks.party](https://binternet.ducks.party) | no | no | 🇳🇱 NL |
-| [binternet.4o1x5.dev](https://binternet.4o1x5.dev) | no | no | 🇭🇺 HU |
-| [binternet.darkness.services](https://binternet.darkness.services) | [yes!](http://binternet.darknessrdor43qkl2ngwitj72zdavfz2cead4t5ed72bybgauww5lyd.onion/) | no | 🇺🇸 US |
-| [binternet.privacyredirect.com](https://binternet.privacyredirect.com) | no | no | 🇫🇮 FI |
-| [binternet.lunar.icu](https://binternet.lunar.icu) | no | no | 🇩🇪 DE |
-| [binternet.bunk.lol](https://binternet.bunk.lol) | no | no | 🇮🇸 IS |
-| [pin.blitzw.in](https://pin.blitzw.in) | no | no | 🇩🇰 DK |
-| [binternet.canine.tools](https://binternet.canine.tools) | no | no | 🇺🇸 US |
+| [binternet.revvy.de](https://binternet.revvy.de/) | [yes!](http://binternet.revvybrr6pvbx4n3j4475h4ghw4elqr4t5xo2vtd3gfpu2nrsnhh57id.onion/) | [yes!](http://revznkqdwy7nmlzql66x226g3qnapiooss3rg2uajbj4rypxjnba.b32.i2p/) | 🇫🇮 FI |
+| [binternet.darkness.services](https://binternet.darkness.services/) | [yes!](http://binternet.darknessrdor43qkl2ngwitj72zdavfz2cead4t5ed72bybgauww5lyd.onion/) | no | 🇺🇸 US |
+| [bn.bloat.cat](https://bn.bloat.cat/) | no | no | 🇩🇪 DE |
+| [bn.opnxng.com](https://bn.opnxng.com/) | no | no | 🇸🇬 SG |
+| [binternet.ducks.party](https://binternet.ducks.party/) | no | no | 🇳🇱 NL |
+| [binternet.4o1x5.dev](https://binternet.4o1x5.dev/) | no | no | 🇭🇺 HU |
+| [binternet.privacyredirect.com](https://binternet.privacyredirect.com/) | no | no | 🇫🇮 FI |
+| [binternet.lunar.icu](https://binternet.lunar.icu/) | no | no | 🇩🇪 DE |
+| [pin.blitzw.in](https://pin.blitzw.in/) | no | no | 🇩🇰 DK |
+| [binternet.canine.tools](https://binternet.canine.tools/) | no | no | 🇺🇸 US |
 <br>
 
 

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,4 +1,9 @@
 server {
+    add_header Content-Security-Policy "default-src 'none'; style-src 'self'; img-src 'self'";
+    add_header X-Frame-Options "DENY" always;
+    add_header X-Content-Type-Options "nosniff";
+    add_header Permissions-Policy "accelerometer=(), ambient-light-sensor=(), attribution-reporting=(), autoplay=(), bluetooth=(), browsing-topics=(), camera=(), compute-pressure=(), display-capture=(), document-domain=(), encrypted-media=(), fullscreen=(), gamepad=(), geolocation=(), gyroscope=(), hid=(), indentity-credentials-get=(), idle-detection=(), local-fonts=(), magnetometer=(), microphone=(), midi=(), otp-credentials=(), payment=(), picture-in-picture=(), publickey-credentials-create=(), publickey-credentials-get=(), screen-wake-lock=(), serial=(), speaker-selection=(), storage-access=(), usb=(), web-share=(), window-management=(), xr-spatial-tracking=()";
+
     listen       8080 default_server;
     server_name  _;
 
@@ -6,7 +11,7 @@ server {
     index    index.php;
 
     location ~ \.php$ {
-        fastcgi_pass   unix:/run/php/php-fpm83.sock;
+        fastcgi_pass   unix:/run/php/php-fpm84.sock;
         fastcgi_index  index.php;
         fastcgi_param  PATH_INFO $path_info;
         fastcgi_param  SCRIPT_FILENAME    $document_root$fastcgi_script_name;


### PR DESCRIPTION
- Update Alpine Linux to 3.21
- Update to PHP 8.4
    - php-json is no longer available in repos, as it has been merged into the core PHP [source](https://www.php.net/manual/en/json.installation.php)
    - Actually replace user/group php-fpm configuration
- Update instances list
    - Add binternet.revvy.de (currently broken due to a ZeroSSL outage, will be up soon)
    - Remove dead instances
    - Reorder according to official instance/Tor/I2P hierarchy.
    - Add trailing slashes for consistency
- Add nginx security headers (Content-Security-Policy, X-Frame-Options, X-Content-Type-Options, Permissions-Policy)