### PR TITLE
Fix search results being empty

### DIFF
--- a/search.php
+++ b/search.php
@@ -55,7 +55,9 @@ $prepare_search_curl_obj = function ($query, $bookmark) use ($url, $header_funct
     }
 
     $data_param = urlencode(json_encode($data_param_obj));
-    $headers = [];
+    $headers = [
+        "x-pinterest-pws-handler: www/search/[scope].js"
+    ];
     
     if ($csrftoken !== null) {
         $headers[] = "x-csrftoken: $csrftoken";


### PR DESCRIPTION
Fixes #50 by adding the x-pinterest-pws-handler header inside the search function
![WindowsTerminal_nm6TOe4fkD](https://github.com/user-attachments/assets/ca441a37-10d1-44c7-ab8c-42eaf7c8d65e)
![WindowsTerminal_kXa19FIA3G](https://github.com/user-attachments/assets/231d5455-81b4-405d-9a71-6137e443ce20)
![librewolf_8VoAqq1nwJ](https://github.com/user-attachments/assets/dc1e4e7f-16ee-42b8-b098-6c8e3dbe8447)
