### PR TITLE
Add nadeko.net instance and remove outdated instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,17 +33,12 @@
 
 | Clearnet | TOR | I2P | Country |
 |-|-|-|-|
-| [binternet.revvy.de](https://binternet.revvy.de/) | [yes!](http://binternet.revvybrr6pvbx4n3j4475h4ghw4elqr4t5xo2vtd3gfpu2nrsnhh57id.onion/) | [yes!](http://revznkqdwy7nmlzql66x226g3qnapiooss3rg2uajbj4rypxjnba.b32.i2p/) | 🇫🇮 FI |
-| [binternet.darkness.services](https://binternet.darkness.services/) | [yes!](http://binternet.darknessrdor43qkl2ngwitj72zdavfz2cead4t5ed72bybgauww5lyd.onion/) | no | 🇺🇸 US |
 | [binternet.nadeko.net](https://binternet.nadeko.net/) | [yes!](http://binternet.nadeko24jhlqccyfnmvynwkojcfzmub53m74y5b7l5e6hn55jlml4pqd.onion/) | no | 🇺🇸 US |
 | [bn.bloat.cat](https://bn.bloat.cat/) | no | no | 🇩🇪 DE |
 | [bn.opnxng.com](https://bn.opnxng.com/) | no | no | 🇸🇬 SG |
-| [binternet.ducks.party](https://binternet.ducks.party/) | no | no | 🇳🇱 NL |
 | [binternet.4o1x5.dev](https://binternet.4o1x5.dev/) | no | no | 🇭🇺 HU |
 | [binternet.privacyredirect.com](https://binternet.privacyredirect.com/) | no | no | 🇫🇮 FI |
-| [binternet.lunar.icu](https://binternet.lunar.icu/) | no | no | 🇩🇪 DE |
 | [binternet.canine.tools](https://binternet.canine.tools/) | no | no | 🇺🇸 US |
-| [bn.kuuro.net](https://bn.kuuro.net/) | no | no | 🇺🇸 US |
 | [binternet.privadency.com](https://binternet.privadency.com/) | no | no | 🇩🇪 DE |
 <br>
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <h3 align="center">Mirrors</h3>
 
 <div align="center">
- 
+
 [GitHub](https://github.com/Ahwxorg/Binternet)
 
 > Because of PRs/issues, I will use GitHub for now. If you don't like GitHub, you can use one of the [GotHub](https://codeberg.org/gothub/gothub) instances.
@@ -35,6 +35,7 @@
 |-|-|-|-|
 | [binternet.revvy.de](https://binternet.revvy.de/) | [yes!](http://binternet.revvybrr6pvbx4n3j4475h4ghw4elqr4t5xo2vtd3gfpu2nrsnhh57id.onion/) | [yes!](http://revznkqdwy7nmlzql66x226g3qnapiooss3rg2uajbj4rypxjnba.b32.i2p/) | 🇫🇮 FI |
 | [binternet.darkness.services](https://binternet.darkness.services/) | [yes!](http://binternet.darknessrdor43qkl2ngwitj72zdavfz2cead4t5ed72bybgauww5lyd.onion/) | no | 🇺🇸 US |
+| [binternet.nadeko.net](https://binternet.nadeko.net/) | [yes!](http://binternet.nadeko24jhlqccyfnmvynwkojcfzmub53m74y5b7l5e6hn55jlml4pqd.onion/) | no | 🇺🇸 US |
 | [bn.bloat.cat](https://bn.bloat.cat/) | no | no | 🇩🇪 DE |
 | [bn.opnxng.com](https://bn.opnxng.com/) | no | no | 🇸🇬 SG |
 | [binternet.ducks.party](https://binternet.ducks.party/) | no | no | 🇳🇱 NL |


### PR DESCRIPTION
Title, this is my instance, I also created another commit to remove the outdated instances from the list:

https://binternet.revvy.de/: Page shows "Redirecting..."
https://binternet.darkness.services/: Returns "404 page not found"
https://binternet.ducks.party/: Times out
https://binternet.lunar.icu/: Times out
https://bn.kuuro.net/: Returns 404 with "DEPLOYMENT_NOT_FOUND" code (Was
hosted in vercel it seems)

If you want me to revert that commit, just tell me! :3